### PR TITLE
Use raw github content for ansible galaxy requirements (#45)

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -302,7 +302,7 @@ Cloudera Deploy does have a single dependency for its own execution, the https:/
 [source, bash]
 ----
 # Get the cldr-runner dependency file first
-curl https://github.com/cloudera-labs/cldr-runner/tree/main/payload/deps/ansible.yml \
+curl https://raw.githubusercontent.com/cloudera-labs/cldr-runner/main/payload/deps/ansible.yml \
     --output requirements.yml
 
 # Install the collections (and their dependencies)


### PR DESCRIPTION
The current URL specified links to the file as viewed in the GitHub UI, calling `curl` on that will download HTTP code, not a formatted YAML file.

Signed-off-by: Steve Martinelli <s.martinelli@gmail.com>